### PR TITLE
fix: use symbols for anchor identity paths

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -979,7 +979,7 @@
                   cursor $ :cursor states
                   state $ either (:data states)
                     {} (:show? false) (:text nil)
-                  *next-confirm-task $ anchor-state (identity-path 'confirm)
+                  *next-confirm-task $ anchor-state (identity-path confirm)
                   node $ comp-confirm-modal
                     if
                       blank? $ :text state
@@ -1095,7 +1095,7 @@
                   cursor $ :cursor states
                   state $ either (:data states)
                     {} (:show? false) (:failure nil)
-                  *next-prompt-task $ anchor-state (identity-path 'prompt)
+                  *next-prompt-task $ anchor-state (identity-path prompt)
                   node $ comp-prompt-modal (>> states :modal) options (:show? state)
                     fn (text d!)
                       if (some? @*next-prompt-task) (@*next-prompt-task text)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,8 +1,9 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo-alerts)
-  :configs $ {} (:init-fn |respo-alerts.main/main!) (:reload-fn |respo-alerts.main/reload!) (:version |0.10.13)
-    :modules $ [] |lilac/ |memof/ |respo.calcit/ |respo-ui.calcit/ |reel.calcit/
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo-alerts) (:version |0.10.14)
   :entries $ {}
+    :default $ {} (:description |) (:init-fn 'respo-alerts.main/main!) (:mode :native) (:reload-fn 'respo-alerts.main/reload!)
+      :modules $ [] |lilac/ |memof/ |respo.calcit/ |respo-ui.calcit/ |reel.calcit/
+      :type-slots $ {}
   :files $ {}
     |respo-alerts.comp.container $ %{} :FileEntry
       :defs $ {}
@@ -183,7 +184,6 @@
             respo.comp.inspect :refer $ comp-inspect
             respo-alerts.style :as style
             |@calcit/std :refer $ rand-int
-            respo-alerts.trigger :refer $ comp-trigger
             respo-alerts.trigger :refer $ comp-trigger
     |respo-alerts.config $ %{} :FileEntry
       :defs $ {}
@@ -1131,7 +1131,6 @@
             respo-alerts.style :as style
             respo-alerts.schema :as schema
             respo-alerts.util :refer $ focus-element! select-element!
-            respo-alerts.style :as style
             memof.anchor :refer $ anchor-state identity-path
     |respo-alerts.main $ %{} :FileEntry
       :defs $ {}
@@ -1313,7 +1312,7 @@
           :examples $ []
           :schema $ :: :fn
             {} (:return :map)
-              :args $ [] :map :list :string :number
+              :args $ [] :map :tuple :string :number
       :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns respo-alerts.updater $ :require

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,8 +1,8 @@
 
-{} (:calcit-version |0.12.49)
+{} (:calcit-version |0.12.55)
   :dependencies $ {} (|Respo/reel.calcit |0.6.4)
-    |Respo/respo-markdown.calcit |0.4.14
+    |Respo/respo-markdown.calcit |0.4.19
     |Respo/respo-ui.calcit |0.6.5
-    |Respo/respo.calcit |0.16.48
+    |Respo/respo.calcit |0.16.59
     |calcit-lang/lilac |0.5.1
-    |calcit-lang/memof |0.0.24
+    |calcit-lang/memof |0.0.26

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "vite": "^8.0.11"
   },
   "dependencies": {
-    "@calcit/procs": "^0.12.49"
+    "@calcit/procs": "^0.12.55"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.12.49":
-  version: 0.12.49
-  resolution: "@calcit/procs@npm:0.12.49"
+"@calcit/procs@npm:^0.12.55":
+  version: 0.12.55
+  resolution: "@calcit/procs@npm:0.12.55"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/45db4a02e75ed95e306ad9f979cc8ced6bca9a2dccb8948802f41e50b69b2c8b637034e13a96213fd0151e88e95b9d8c5e1843c8a6d5b5ba5b8fac88498794eb
+  checksum: 10c0/8476617907a107747adc11767f2db05f1bef1dbc257988943a97d39f678e99bcaa43db68a47d681176152d23d9b5eb73d16c07523394720abd6d5aef1bb62db7
   languageName: node
   linkType: hard
 
@@ -994,7 +994,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.12.49"
+    "@calcit/procs": "npm:^0.12.55"
     "@calcit/std": "npm:^0.0.3"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.0.11"


### PR DESCRIPTION
Calcit 0.13 no longer treats quoted literals (`'prompt`, `'confirm`) as symbol macro arguments. `memof.anchor/identity-path` expects symbols, so these hooks fail during preprocessing. Use bare symbols to preserve the intended identity paths and keep the module compatible with current Calcit.