### PR TITLE
chore: upgrade to Calcit 0.13.13

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,6 +1,6 @@
 
-{} (:calcit-version |0.13.10)
-  :dependencies $ {} (|Respo/reel.calcit |0.6.5)
-    |Respo/respo-markdown.calcit |0.4.21
-    |Respo/respo-ui.calcit |0.7.2
+{} (:calcit-version |0.13.13)
+  :dependencies $ {} (|Respo/reel.calcit |0.6.6)
+    |Respo/respo-markdown.calcit |0.4.22
+    |Respo/respo-ui.calcit |0.7.6
     |Respo/respo.calcit |0.16.67

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "vite": "^8.0.11"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.10"
+    "@calcit/procs": "^0.13.13"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.10":
-  version: 0.13.10
-  resolution: "@calcit/procs@npm:0.13.10"
+"@calcit/procs@npm:^0.13.13":
+  version: 0.13.13
+  resolution: "@calcit/procs@npm:0.13.13"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/6352452f00f7a73e071ea0fa944431174cd6da49b2f63ba501c4046ee029dae4b1b0f06a9ef6e59c86492ba2d558af6d51780a2ab50a89ae301772184cad7ea7
+  checksum: 10c0/2f05ccfef08bc971aea97536bf8dd3cb4f1edc67acad8d377b98ecd015a0b01ef674193d92b218c1623b56f772f09e19733b5ec45ab01f4dfba35a4ceadd6295
   languageName: node
   linkType: hard
 
@@ -994,7 +994,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.10"
+    "@calcit/procs": "npm:^0.13.13"
     "@calcit/std": "npm:^0.0.3"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.0.11"


### PR DESCRIPTION
Upgrades the Calcit runtime and resolved module dependencies to 0.13.13.\n\nValidated locally with `caps --ci` (project-scoped module links) and `cr js`.