### PR TITLE
chore: upgrade alerts to Calcit 0.13.15

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,6 +1,6 @@
 
-{} (:calcit-version |0.13.13)
+{} (:calcit-version |0.13.15)
   :dependencies $ {} (|Respo/reel.calcit |0.6.6)
     |Respo/respo-markdown.calcit |0.4.22
     |Respo/respo-ui.calcit |0.7.7
-    |Respo/respo.calcit |0.16.67
+    |Respo/respo.calcit |0.16.69

--- a/history/202608131725-upgrade-calcit-0.13.15.md
+++ b/history/202608131725-upgrade-calcit-0.13.15.md
@@ -1,0 +1,10 @@
+# Upgrade respo/alerts.calcit to Calcit 0.13.15
+
+## Change summary
+
+- Synced `deps.cirru`, `@calcit/procs`, and the Yarn lockfile to Calcit 0.13.15.
+- Kept the existing single canonical snapshot and current typed declarations unchanged.
+
+## Knowledge point
+
+An already canonical project can usually upgrade the version chain independently. Preserve existing Dynamic boundary warnings as an explicit baseline when check-only, JS generation, and the production Vite build all pass without deprecated API diagnostics.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "vite": "^8.0.11"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.13"
+    "@calcit/procs": "^0.13.15"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.13":
-  version: 0.13.13
-  resolution: "@calcit/procs@npm:0.13.13"
+"@calcit/procs@npm:^0.13.15":
+  version: 0.13.15
+  resolution: "@calcit/procs@npm:0.13.15"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/2f05ccfef08bc971aea97536bf8dd3cb4f1edc67acad8d377b98ecd015a0b01ef674193d92b218c1623b56f772f09e19733b5ec45ab01f4dfba35a4ceadd6295
+  checksum: 10c0/f37687aac090b2a286f916ea3c9d9cc173d4f606d1f02d5e57e192cbf375277a05bcd5f0a75d890b2827635dec9959034046ea626fda8900b8fe2c7f5c4c3e8a
   languageName: node
   linkType: hard
 
@@ -994,7 +994,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.13"
+    "@calcit/procs": "npm:^0.13.15"
     "@calcit/std": "npm:^0.0.3"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.0.11"


### PR DESCRIPTION
## Summary
- sync Calcit and @calcit/procs to 0.13.15
- keep the canonical snapshot and current typed declarations

## Validation
- cr 0.13.15 --check-only (ulimit -s 16384)
- JS code generation
- Yarn immutable install
- Vite production build

Existing Dynamic usage remains 97/151 (64.2%); no legacy Lilac/Memof/calcit-test references found.